### PR TITLE
1 error nonexistent endpoint

### DIFF
--- a/Api/Startup.cs
+++ b/Api/Startup.cs
@@ -94,6 +94,8 @@ namespace Api
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
+            app.UseSecurityHeaders();
+
             app.UseMiddleware<ExceptionMiddleware>();
 
             // Handle unexisting endpoints (this middleware doesn't catch exceptions)
@@ -104,8 +106,6 @@ namespace Api
                 // Set Strict-Transport-Security response header
                 app.UseHsts();
             }
-
-            app.UseSecurityHeaders();
 
             app.UseHttpsRedirection();
 

--- a/docs/postman/5S Audit App.postman_collection.json
+++ b/docs/postman/5S Audit App.postman_collection.json
@@ -364,6 +364,24 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "GET nonexistent endpoint",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{url}}/api/pathThatDoesNotExist",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"pathThatDoesNotExist"
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		},


### PR DESCRIPTION
Fixes #1. 

The order of middleware matters. The security headers middleware should be first in the pipeline to apply the headers to all requests.

Updated Postman collection with test request for unknown paths.